### PR TITLE
.NET Core 

### DIFF
--- a/BLM.EF6.Tests/BLM.EF6.Tests.csproj
+++ b/BLM.EF6.Tests/BLM.EF6.Tests.csproj
@@ -60,10 +60,6 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Runtime.Caching.Generic, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Caching.Generic.1.0.5.0\lib\net40\System.Runtime.Caching.Generic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Transactions" />
   </ItemGroup>
   <ItemGroup>

--- a/BLM.EF6.Tests/packages.config
+++ b/BLM.EF6.Tests/packages.config
@@ -3,5 +3,4 @@
   <package id="Effort.EF6" version="1.3.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="NMemory" version="1.1.2" targetFramework="net452" />
-  <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
 </packages>

--- a/BLM.EF6/BLM.EF6.csproj
+++ b/BLM.EF6/BLM.EF6.csproj
@@ -42,10 +42,6 @@
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Caching.Generic, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Caching.Generic.1.0.5.0\lib\net40\System.Runtime.Caching.Generic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>

--- a/BLM.EF6/packages.config
+++ b/BLM.EF6/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/BLM.Tests/BLM.Tests.csproj
+++ b/BLM.Tests/BLM.Tests.csproj
@@ -42,10 +42,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Caching.Generic, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Caching.Generic.1.0.5.0\lib\net40\System.Runtime.Caching.Generic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AuthorizerTests.cs" />
@@ -60,9 +56,6 @@
     <Compile Include="MockRemoveAuthorizer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TypeLoaderTests.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\BLM\BLM.csproj">

--- a/BLM.Tests/packages.config
+++ b/BLM.Tests/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
-</packages>

--- a/BLM/BLM.csproj
+++ b/BLM/BLM.csproj
@@ -36,10 +36,6 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Caching.Generic, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.Caching.Generic.1.0.5.0\lib\net40\System.Runtime.Caching.Generic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
       <Private>True</Private>
@@ -89,7 +85,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="BLM.nuspec" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/BLM/packages.config
+++ b/BLM/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
NuGet package named "System.Runtime.Caching.Generic" removed, because it was not used, and it's not compatible with .NET Core